### PR TITLE
Remove unused PLATFORM_SCHEMA import (fixes #3)

### DIFF
--- a/custom_components/ourgroceries/__init__.py
+++ b/custom_components/ourgroceries/__init__.py
@@ -8,7 +8,6 @@ import voluptuous as vol
 
 from homeassistant.components import http
 from homeassistant.components.http.data_validator import RequestDataValidator
-from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform


### PR DESCRIPTION
The presence of the `PLATFORM_SCHEMA` name in addition to `CONFIG_SCHEMA` seems to mess up the config validation by Home Assistant. Removing this appears to fix the config validation issues described in #3.