### PR TITLE
Rename property in sensor.py

### DIFF
--- a/custom_components/ourgroceries/sensor.py
+++ b/custom_components/ourgroceries/sensor.py
@@ -39,7 +39,7 @@ class OurGroceriesSensor(Entity):
         return shopping_lists + recipes
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         return {
             ATTR_RECIPES: self._lists.get('recipes'),


### PR DESCRIPTION
Rename the property **device_state_attributes** to **extra_state_attributes** in sensor.py to avoid error with custom component is using device_state_attributes.

[https://developers.home-assistant.io/docs/core/entity?_highlight=extra_state_attributes#generic-properties](https://developers.home-assistant.io/docs/core/entity?_highlight=extra_state_attributes#generic-properties)